### PR TITLE
get fails if data is null

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ module.exports = function (connect) {
 		.get(sid)
 		.then(function (data) {
 			debug('GOT %j', data);
-			return data.session;
+			return data ? data.session : null;
 		}).asCallback(fn);
 	};
 

--- a/index.js
+++ b/index.js
@@ -45,9 +45,8 @@ module.exports = function (connect) {
 		})
 
 		self.clearInterval = setInterval(function () {
-			var now = Date.now();
 			self.r.table(self.options.table)
-			.between(0, now, {index: 'expires'})
+			.between(0, r.now(), {index: 'expires'})
 			.delete()
 			.run()
 			.tap(function (result) {


### PR DESCRIPTION
On express 4 the session is not created before get is called, this causes the get to fail because data will be null from rethinkdb