### PR TITLE
Change to passing an existing `rethinkdbdash` instance.

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,8 +14,8 @@ module.exports = function (connect) {
 
 		if (options === null || options === undefined) {
 			self.r = require('rethinkdbdash')();
-		} else if (typeof options === 'function') {
-			self.r = options;
+		} else if (options && options.r && typeof options.r === 'function') {
+			self.r = options.r;
 		} else if (typeof options === 'object') {
 			self.r = require('rethinkdbdash')(options);
 		} else {


### PR DESCRIPTION
If you want to pass an existing instance, you now do so by passing it
as `options.r` (not as options). This stops self.options.table from
overwritting self.r.table fixing issue #10 